### PR TITLE
Update pgrx to update to Postgres 16. Minor docs improvement

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,27 +1,27 @@
 [package]
 name = "pgfaker"
-version = "0.0.1"
+version = "0.0.2"
 edition = "2021"
 
 [lib]
 crate-type = ["cdylib"]
 
 [features]
-default = ["pg15"]
-pg11 = ["pgrx/pg11", "pgrx-tests/pg11" ]
+default = ["pg16"]
 pg12 = ["pgrx/pg12", "pgrx-tests/pg12" ]
 pg13 = ["pgrx/pg13", "pgrx-tests/pg13" ]
 pg14 = ["pgrx/pg14", "pgrx-tests/pg14" ]
 pg15 = ["pgrx/pg15", "pgrx-tests/pg15" ]
+pg16 = ["pgrx/pg16", "pgrx-tests/pg16" ]
 pg_test = []
 
 [dependencies]
-pgrx = "=0.9.0"
+pgrx = "=0.10.2"
 faker_rand = "0.1.1"
 rand = "0.8.2"
 
 [dev-dependencies]
-pgrx-tests = "=0.9.0"
+pgrx-tests = "=0.10.2"
 
 [profile.dev]
 panic = "unwind"

--- a/README.md
+++ b/README.md
@@ -23,6 +23,21 @@ SELECT pgfaker.company(), pgfaker.person_first_name(), pgfaker.person_last_name(
 ;
 ```
 
+```bash
+┌─[ RECORD 1 ]──────┬─────────────────────────────┐
+│ company           │ Jacobson-Wyman              │
+│ person_first_name │ Adell                       │
+│ person_last_name  │ Treutel                     │
+│ person_prefix     │ Mr.                         │
+│ person_suffix     │ Jr.                         │
+│ email             │ mwhite6@glover.net          │
+│ phone             │ (907) 125-0407              │
+│ slogan            │ Configurable scalable users │
+│ username          │ dwalker                     │
+│ domain            │ weissnat.name               │
+└───────────────────┴─────────────────────────────┘
+```
+
 
 
 ## Creating installer for your system

--- a/build/build.sh
+++ b/build/build.sh
@@ -5,10 +5,10 @@ BASE=$(dirname `pwd`)
 VERSION=$(cat $BASE/pgfaker.control | grep default_version | cut -f2 -d\')
 LOGDIR=${BASE}/target/logs
 ARTIFACTDIR=${BASE}/target/artifacts
-PGRXVERSION=0.9.0
+PGRXVERSION=0.10.2
 
-#PG_VERS=("pg11" "pg12" "pg13" "pg14" "pg15")
-PG_VERS=("pg15")
+#PG_VERS=("pg12" "pg13" "pg14" "pg15" "pg16")
+PG_VERS=("pg16")
 
 echo $BASE
 echo $VERSION

--- a/build/docker/pgfaker-debian-11/Dockerfile
+++ b/build/docker/pgfaker-debian-11/Dockerfile
@@ -1,4 +1,6 @@
-FROM debian:11
+# Uses the PostGIS image used by PgOSM Flex. At time of writing
+# it was Debian 11 (bullseye)
+FROM postgis/postgis:16-3.4
 
 LABEL maintainer="PgFaker Project - https://github.com/rustprooflabs/pgfaker"
 
@@ -13,9 +15,7 @@ RUN useradd -m ${USER} --uid=${UID}
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get upgrade -y \
     && apt-get install -y make wget curl gnupg git postgresql-common \
-         lsb-release wget software-properties-common gnupg \
-    # Install latest clang and llvm per https://apt.llvm.org/ 
-    && bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)"
+         lsb-release wget software-properties-common gnupg
 
 RUN sh /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -y
 
@@ -28,11 +28,11 @@ RUN apt-get install -y --fix-missing \
         libldap-dev libkrb5-dev gettext tcl-tclreadline tcl-dev libperl-dev \
         libpython3-dev libprotobuf-c-dev libprotobuf-dev gcc \
         ruby ruby-dev rubygems \
-        postgresql-11 postgresql-server-dev-11 \
         postgresql-12 postgresql-server-dev-12 \
         postgresql-13 postgresql-server-dev-13 \
         postgresql-14 postgresql-server-dev-14 \
         postgresql-15 postgresql-server-dev-15 \
+        postgresql-16 postgresql-server-dev-16 \
     && apt autoremove -y
 
 

--- a/pgfaker.control
+++ b/pgfaker.control
@@ -1,5 +1,5 @@
 comment = 'Create Fake data in Postgres.  Created using pgrx, wraps around Rust faker libraries.'
-default_version = '0.0.1'
+default_version = '0.0.2'
 module_pathname = '$libdir/pgfaker'
 relocatable = false
 superuser = true


### PR DESCRIPTION
Adjusted clang/llvm handling per https://github.com/pgcentralfoundation/pgrx/issues/1298

Not sure why I was installing the latest versions, which resulted in 11, 13 and 17 all being installed. Seems to be okay without.  11 is what Postgres dev packages require on Debian 11.